### PR TITLE
Add CCSDSPY to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy>=1.18.0
 astropy>=5.3.3
+ccsdspy==1.3.*
 sunpy>=5.0.1 # not currently needed
 ndcube>=2.2.0 # Adding NDCube to support spectra and high-dimensional data in hermes_core data container
 flake8==7.0.0 # for code style


### PR DESCRIPTION
Adds the same `ccsdspy` dependency that is defined in the padre_meddea dependencies to the base docker image to keep things consistent and ensure users don't need to install the package.